### PR TITLE
Fix critical bugs in circular padding and RoPE

### DIFF
--- a/nodes_circular_rope.py
+++ b/nodes_circular_rope.py
@@ -10,24 +10,26 @@ Supports: FLUX.1/2, Qwen-Image, Z-Image, and other DiT-based models.
 
 import torch
 import torch.nn as nn
-from typing import Optional
-
-# ComfyUI imports
-try:
-    import comfy.model_patcher
-    COMFYUI_AVAILABLE = True
-except ImportError:
-    COMFYUI_AVAILABLE = False
 
 # Local imports
 try:
-    from .utils.circular_rope import (
-        patch_model_for_circular_rope,
-    )
+    from .utils.circular_rope import create_circular_rope_wrapper
 except ImportError:
-    from utils.circular_rope import (
-        patch_model_for_circular_rope,
-    )
+    from utils.circular_rope import create_circular_rope_wrapper
+
+
+def find_rope_embedder(model):
+    """Find the RoPE position embedder in a model."""
+    # Get the actual model
+    base = model.model if hasattr(model, 'model') else model
+    diff = base.diffusion_model if hasattr(base, 'diffusion_model') else base
+
+    # Check common attribute names (in priority order for FLUX)
+    for name in ['pe_embedder', 'pos_embed', 'rope_embedder', 'position_embedder']:
+        if hasattr(diff, name):
+            return name, getattr(diff, name)
+
+    return None, None
 
 
 class ApplyCircularRoPE:
@@ -43,13 +45,6 @@ class ApplyCircularRoPE:
         return {
             "required": {
                 "model": ("MODEL",),
-                "model_type": ([
-                    "auto",
-                    "flux",
-                    "qwen",
-                    "zimage",
-                    "generic",
-                ], {"default": "auto"}),
             },
             "optional": {
                 "enable": ("BOOLEAN", {"default": True}),
@@ -61,27 +56,38 @@ class ApplyCircularRoPE:
     FUNCTION = "apply_circular_rope"
     CATEGORY = "DiT360/position_encoding"
 
-    def apply_circular_rope(
-        self,
-        model,
-        model_type: str = "auto",
-        enable: bool = True
-    ):
+    def apply_circular_rope(self, model, enable: bool = True):
         if not enable:
             return (model,)
 
         model_clone = model.clone()
 
-        success = patch_model_for_circular_rope(
-            model_clone,
-            circular_axis=-1,  # X (horizontal) axis
-            model_type=model_type
-        )
+        # Find the embedder
+        attr_name, embedder = find_rope_embedder(model_clone)
 
-        if success:
-            print(f"[CircularRoPE] Patched for circular topology")
-        else:
-            print("[CircularRoPE] Warning: Could not patch model")
+        if embedder is None:
+            print("[CircularRoPE] Warning: Could not find RoPE embedder")
+            return (model_clone,)
+
+        # Create wrapped embedder
+        wrapped = create_circular_rope_wrapper(embedder, circular_axis=-1)
+
+        # Try add_object_patch first (preferred ComfyUI method)
+        patched = False
+        if hasattr(model_clone, 'add_object_patch'):
+            try:
+                model_clone.add_object_patch(f"diffusion_model.{attr_name}", wrapped)
+                patched = True
+                print(f"[CircularRoPE] Patched via add_object_patch: {attr_name}")
+            except Exception as e:
+                print(f"[CircularRoPE] add_object_patch failed: {e}")
+
+        # Fallback to direct setattr
+        if not patched:
+            base = model_clone.model if hasattr(model_clone, 'model') else model_clone
+            diff = base.diffusion_model if hasattr(base, 'diffusion_model') else base
+            setattr(diff, attr_name, wrapped)
+            print(f"[CircularRoPE] Patched via setattr: {attr_name}")
 
         return (model_clone,)
 
@@ -98,13 +104,6 @@ class ApplyCircularPanorama:
         return {
             "required": {
                 "model": ("MODEL",),
-                "model_type": ([
-                    "auto",
-                    "flux",
-                    "qwen",
-                    "zimage",
-                    "generic",
-                ], {"default": "auto"}),
             },
             "optional": {
                 "patch_conv2d": ("BOOLEAN", {"default": True}),
@@ -120,16 +119,10 @@ class ApplyCircularPanorama:
     def apply_all(
         self,
         model,
-        model_type: str = "auto",
         patch_conv2d: bool = True,
         patch_rope: bool = True,
     ):
         model_clone = model.clone()
-
-        # Detect model type
-        if model_type == "auto":
-            model_type = self._detect_model_type(model_clone)
-
         patches = []
 
         # Patch Conv2d layers for circular padding
@@ -140,28 +133,33 @@ class ApplyCircularPanorama:
 
         # Patch RoPE for circular topology
         if patch_rope:
-            if patch_model_for_circular_rope(model_clone, circular_axis=-1, model_type=model_type):
+            attr_name, embedder = find_rope_embedder(model_clone)
+
+            if embedder is not None:
+                wrapped = create_circular_rope_wrapper(embedder, circular_axis=-1)
+
+                # Try add_object_patch first
+                patched = False
+                if hasattr(model_clone, 'add_object_patch'):
+                    try:
+                        model_clone.add_object_patch(f"diffusion_model.{attr_name}", wrapped)
+                        patched = True
+                    except Exception:
+                        pass
+
+                if not patched:
+                    base = model_clone.model if hasattr(model_clone, 'model') else model_clone
+                    diff = base.diffusion_model if hasattr(base, 'diffusion_model') else base
+                    setattr(diff, attr_name, wrapped)
+
                 patches.append("RoPE")
 
         if patches:
             print(f"[CircularPanorama] Patched: {', '.join(patches)}")
+        else:
+            print("[CircularPanorama] Warning: No patches applied")
 
         return (model_clone,)
-
-    def _detect_model_type(self, model) -> str:
-        base = model.model if hasattr(model, 'model') else model
-        if hasattr(base, 'diffusion_model'):
-            class_name = type(base.diffusion_model).__name__.lower()
-        else:
-            class_name = type(base).__name__.lower()
-
-        if 'flux' in class_name:
-            return "flux"
-        elif 'qwen' in class_name:
-            return "qwen"
-        elif 'zimage' in class_name:
-            return "zimage"
-        return "generic"
 
     def _patch_conv2d(self, model) -> int:
         """Patch Conv2d layers to use circular padding."""

--- a/utils/circular_rope.py
+++ b/utils/circular_rope.py
@@ -279,7 +279,8 @@ def create_circular_rope_wrapper(original_embedder: nn.Module, circular_axis: in
     """
     Wrap an existing RoPE embedder to use circular positions in one axis.
 
-    This is the key function for patching existing models!
+    This makes position X wrap around so that position 0 and position W-1
+    are adjacent (for seamless 360° panoramas).
 
     Args:
         original_embedder: The model's original position embedder
@@ -287,63 +288,41 @@ def create_circular_rope_wrapper(original_embedder: nn.Module, circular_axis: in
 
     Returns:
         Wrapped embedder that produces circular RoPE
-
-    Example:
-        >>> # For FLUX
-        >>> model.diffusion_model.pos_embed = create_circular_rope_wrapper(
-        ...     model.diffusion_model.pos_embed,
-        ...     circular_axis=-1  # X dimension
-        ... )
     """
     original_forward = original_embedder.forward
 
-    # Get theta_base from original if available
-    theta_base = getattr(original_embedder, 'theta', 10000.0)
-    if hasattr(original_embedder, 'theta_base'):
-        theta_base = original_embedder.theta_base
-
     def circular_forward(ids: torch.Tensor, *args, **kwargs) -> torch.Tensor:
-        """
-        Wrapped forward that applies circular mapping to specified axis.
-        """
-        # Get original output shape info
-        original_output = original_forward(ids, *args, **kwargs)
+        """Apply circular mapping to the specified axis before calling original."""
+        # ids shape: (B, N, num_axes) where axes are typically [t, y, x]
+        if ids.dim() < 2:
+            return original_forward(ids, *args, **kwargs)
 
-        # Determine spatial dimensions
-        # ids typically has shape (B, N, num_axes) where last axis has [t, y, x] or [y, x]
-        if ids.dim() >= 2:
-            n_axes = ids.shape[-1]
+        n_axes = ids.shape[-1]
+        if n_axes < 2:
+            return original_forward(ids, *args, **kwargs)
 
-            # Modify the circular axis (usually X)
-            # Map linear positions to circular angles
-            if ids.shape[-1] >= 2:  # At least 2D spatial
-                modified_ids = ids.clone()
+        axis_idx = circular_axis if circular_axis >= 0 else n_axes + circular_axis
 
-                # Get the axis to make circular
-                axis_idx = circular_axis if circular_axis >= 0 else n_axes + circular_axis
+        # Clone and convert to float for angle computation
+        ids_mod = ids.clone().float()
 
-                # Get max position in this axis to determine "width"
-                max_pos = ids[..., axis_idx].max().item() + 1
+        # Get width from max position (assumes positions are 0..W-1)
+        width = float(ids_mod[..., axis_idx].max().item() + 1.0)
 
-                # Convert to circular: θ = 2π * pos / max_pos
-                circular_pos = 2 * math.pi * ids[..., axis_idx] / max_pos
+        if width > 1.0:
+            # Scale positions to angles: θ = 2π * x / W
+            # This makes position 0 and W-1 adjacent on the circle
+            # RoPE naturally handles the periodicity at 2π
+            ids_mod[..., axis_idx] = ids_mod[..., axis_idx] * (2.0 * math.pi / width)
 
-                # The trick: RoPE uses positions directly in rotation
-                # By scaling positions to [0, 2π), we make the topology circular
-                # because RoPE's rotation naturally wraps at 2π
-                modified_ids[..., axis_idx] = circular_pos / (2 * math.pi / max_pos)
+        return original_forward(ids_mod, *args, **kwargs)
 
-                return original_forward(modified_ids, *args, **kwargs)
-
-        return original_output
-
-    # Create wrapper class that mimics original
     class CircularWrapper(nn.Module):
         def __init__(self, orig):
             super().__init__()
             self._original = orig
-            # Copy attributes
-            for attr in ['theta', 'theta_base', 'axes_dim', 'dim']:
+            # Copy important attributes
+            for attr in ['theta', 'theta_base', 'axes_dim', 'dim', 'in_dim', 'out_dim']:
                 if hasattr(orig, attr):
                     setattr(self, attr, getattr(orig, attr))
 

--- a/utils/padding.py
+++ b/utils/padding.py
@@ -21,45 +21,32 @@ def apply_circular_padding(
 
     Args:
         tensor: Input tensor, can be:
-            - Latent format: (B, C, H, W) where C <= 4
-            - Image format: (B, H, W, C) where C = 3
+            - Latent format: (B, C, H, W) - padding applied to W dimension
+            - Image format: (B, H, W, C) - padding applied to W dimension
         padding: Number of pixels to pad on left/right edges
 
     Returns:
         Padded tensor with wraparound continuity
-
-    Example:
-        >>> latent = torch.rand(1, 4, 128, 256)  # Latent
-        >>> padded = apply_circular_padding(latent, padding=10)
-        >>> padded.shape
-        torch.Size([1, 4, 128, 276])  # Width increased by 20 (10 each side)
-
-        >>> image = torch.rand(1, 1024, 2048, 3)  # Image
-        >>> padded = apply_circular_padding(image, padding=20)
-        >>> padded.shape
-        torch.Size([1, 1024, 2088, 3])  # Width increased by 40 (20 each side)
     """
     if tensor.ndim != 4:
         raise ValueError(f"Expected 4D tensor, got {tensor.ndim}D")
 
-    # Detect format: (B, C, H, W) vs (B, H, W, C)
-    if tensor.shape[1] <= 4:
-        # Latent format: (B, C, H, W)
-        # Take from width dimension (dim 3)
-        left_edge = tensor[:, :, :, :padding]      # Leftmost columns
-        right_edge = tensor[:, :, :, -padding:]    # Rightmost columns
+    # Detect format by checking last dimension
+    # Image format has C=3 or 4 (RGB/RGBA) as last dim
+    # Latent format has W (width, typically large) as last dim
+    is_image_format = tensor.shape[-1] in (3, 4) and tensor.shape[1] > 4
 
-        # Concatenate: right_edge | tensor | left_edge
-        # This wraps the right edge to the left side and vice versa
+    if not is_image_format:
+        # Latent format: (B, C, H, W) - includes FLUX 16-channel
+        # Pad width dimension (dim 3)
+        left_edge = tensor[:, :, :, :padding]
+        right_edge = tensor[:, :, :, -padding:]
         padded = torch.cat([right_edge, tensor, left_edge], dim=3)
-
     else:
         # Image format: (B, H, W, C)
-        # Take from width dimension (dim 2)
-        left_edge = tensor[:, :, :padding, :]      # Leftmost columns
-        right_edge = tensor[:, :, -padding:, :]    # Rightmost columns
-
-        # Concatenate: right_edge | tensor | left_edge
+        # Pad width dimension (dim 2)
+        left_edge = tensor[:, :, :padding, :]
+        right_edge = tensor[:, :, -padding:, :]
         padded = torch.cat([right_edge, tensor, left_edge], dim=2)
 
     return padded
@@ -81,18 +68,14 @@ def remove_circular_padding(
 
     Returns:
         Tensor with padding removed
-
-    Example:
-        >>> padded = torch.rand(1, 4, 128, 276)
-        >>> original = remove_circular_padding(padded, padding=10)
-        >>> original.shape
-        torch.Size([1, 4, 128, 256])
     """
     if tensor.ndim != 4:
         raise ValueError(f"Expected 4D tensor, got {tensor.ndim}D")
 
-    # Detect format and remove padding from width dimension
-    if tensor.shape[1] <= 4:
+    # Detect format by checking last dimension
+    is_image_format = tensor.shape[-1] in (3, 4) and tensor.shape[1] > 4
+
+    if not is_image_format:
         # Latent format: (B, C, H, W)
         return tensor[:, :, :, padding:-padding]
     else:
@@ -213,50 +196,43 @@ def create_circular_padding_wrapper(model, circular_padding: int):
 
 
 def test_circular_padding():
-    """
-    Test function to validate circular padding implementation
-
-    Run this to ensure circular padding works correctly.
-    """
+    """Test circular padding implementation."""
     print("Testing circular padding...")
 
-    # Test 1: Latent format
-    print("\n1. Testing latent format (B, C, H, W)...")
+    # Test 1: SD/SDXL 4-channel latent
+    print("\n1. Testing 4-channel latent (B, C, H, W)...")
     latent = torch.rand(1, 4, 128, 256)
     padded = apply_circular_padding(latent, padding=10)
     unpadded = remove_circular_padding(padded, padding=10)
-
     assert padded.shape == (1, 4, 128, 276), f"Expected (1,4,128,276), got {padded.shape}"
-    assert unpadded.shape == latent.shape, f"Shape mismatch after removing padding"
-    assert torch.allclose(unpadded, latent), "Data corrupted after padding/unpadding"
-    print("   ✓ Latent format works correctly")
+    assert torch.allclose(unpadded, latent), "Data corrupted"
+    print("   ✓ 4-channel latent works")
 
-    # Test 2: Image format
-    print("\n2. Testing image format (B, H, W, C)...")
+    # Test 2: FLUX 16-channel latent
+    print("\n2. Testing FLUX 16-channel latent (B, C, H, W)...")
+    latent = torch.rand(1, 16, 128, 256)
+    padded = apply_circular_padding(latent, padding=16)
+    unpadded = remove_circular_padding(padded, padding=16)
+    assert padded.shape == (1, 16, 128, 288), f"Expected (1,16,128,288), got {padded.shape}"
+    assert torch.allclose(unpadded, latent), "Data corrupted"
+    print("   ✓ FLUX 16-channel latent works")
+
+    # Test 3: Image format
+    print("\n3. Testing image format (B, H, W, C)...")
     image = torch.rand(1, 1024, 2048, 3)
     padded = apply_circular_padding(image, padding=20)
     unpadded = remove_circular_padding(padded, padding=20)
-
     assert padded.shape == (1, 1024, 2088, 3), f"Expected (1,1024,2088,3), got {padded.shape}"
-    assert unpadded.shape == image.shape, f"Shape mismatch after removing padding"
-    assert torch.allclose(unpadded, image), "Data corrupted after padding/unpadding"
-    print("   ✓ Image format works correctly")
+    assert torch.allclose(unpadded, image), "Data corrupted"
+    print("   ✓ Image format works")
 
-    # Test 3: Wraparound continuity
-    print("\n3. Testing wraparound continuity...")
-    latent = torch.rand(1, 4, 128, 256)
+    # Test 4: Wraparound continuity
+    print("\n4. Testing wraparound continuity...")
+    latent = torch.rand(1, 16, 128, 256)
     padded = apply_circular_padding(latent, padding=10)
-
-    # Check that left padding matches original right edge
-    left_pad = padded[:, :, :, :10]
-    original_right = latent[:, :, :, -10:]
-    assert torch.allclose(left_pad, original_right), "Left padding doesn't match original right edge"
-
-    # Check that right padding matches original left edge
-    right_pad = padded[:, :, :, -10:]
-    original_left = latent[:, :, :, :10]
-    assert torch.allclose(right_pad, original_left), "Right padding doesn't match original left edge"
-    print("   ✓ Wraparound continuity verified")
+    assert torch.allclose(padded[:, :, :, :10], latent[:, :, :, -10:]), "Left padding mismatch"
+    assert torch.allclose(padded[:, :, :, -10:], latent[:, :, :, :10]), "Right padding mismatch"
+    print("   ✓ Wraparound verified")
 
     print("\n✅ All circular padding tests passed!\n")
 


### PR DESCRIPTION
Bug 1: padding.py format detection for FLUX 16-channel latents
- Old code assumed channels <= 4 for latent format
- FLUX uses 16 channels, so it was treated as image format
- Was padding HEIGHT instead of WIDTH - causing striped output
- Fixed: detect by checking if last dim is 3/4 (RGB/RGBA)

Bug 2: circular_rope.py scaling canceled itself out
- Was computing: circular_pos = 2π * pos / width
- Then: modified_ids = circular_pos / (2π / width) = pos (original!)
- This meant RoPE was unchanged - no circular effect
- Fixed: simply scale positions to angles without reverting

Bug 3: ComfyUI patching method
- setattr on diffusion_model may not take effect
- Added add_object_patch support (preferred ComfyUI method)
- Falls back to setattr if add_object_patch unavailable

Credit to ChatGPT for identifying the RoPE cancellation bug.